### PR TITLE
Feat/removable token details and market history

### DIFF
--- a/src/pages/Swap/components/details/ShowDetails.tsx
+++ b/src/pages/Swap/components/details/ShowDetails.tsx
@@ -1,46 +1,69 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, Text, Flex, useColorModeValue } from '@chakra-ui/react';
 import { CloseIcon, AddIcon } from '../../../../theme/components/Icons';
+import { removeSideTab, checkSideTab } from '../../../../utils/utilsFunctions';
 
 const ShowDetails = () => {
   const textColor = useColorModeValue('#333333', '#F1F5F8');
   const iconColor = useColorModeValue('#666666', '#DCE5EF');
+  const borderColor = useColorModeValue('#DEE5ED', '#324D68');
+
+  const [sideBarRemoved, setSideBarRemoved] = useState<Boolean>(false);
+
+  useEffect(() => {
+    const isActive = checkSideTab('details');
+    setSideBarRemoved(isActive);
+  }, []);
 
   return (
-    <Box w="100%" pl={3} pr={3}>
-      <Flex alignItems="center" justifyContent="space-between" px={4}>
-        <Text fontWeight="400" fontSize="16px" color={textColor}>
-          Details
-        </Text>
-        <Flex alignItems="center" fontWeight="bold" rounded={100} bg="#">
-          <Flex
-            border="2px"
-            alignItems="center"
-            justifyContent="center"
-            mr={2}
-            color={iconColor}
-            borderColor={iconColor}
-            w="22px"
-            h="22px"
-            borderRadius="6px"
-          >
-            <AddIcon />
-          </Flex>
-          <Flex
-            border="2px"
-            alignItems="center"
-            justifyContent="center"
-            color={iconColor}
-            borderColor={iconColor}
-            w="22px"
-            h="22px"
-            borderRadius="6px"
-          >
-            <CloseIcon />
+    <Flex
+      h="60px"
+      border="1px"
+      borderColor={borderColor}
+      borderRadius="6px"
+      display={sideBarRemoved && 'none'}
+      alignItems="center"
+    >
+      <Box w="100%" my={4} pl={3} pr={3}>
+        <Flex alignItems="center" justifyContent="space-between" px={4}>
+          <Text fontWeight="400" fontSize="16px" color={textColor}>
+            Details
+          </Text>
+          <Flex alignItems="center" fontWeight="bold" rounded={100} bg="#">
+            <Flex
+              border="2px"
+              alignItems="center"
+              justifyContent="center"
+              mr={2}
+              color={iconColor}
+              borderColor={iconColor}
+              w="22px"
+              h="22px"
+              borderRadius="6px"
+            >
+              <AddIcon />
+            </Flex>
+            <Flex
+              border="2px"
+              alignItems="center"
+              justifyContent="center"
+              color={iconColor}
+              borderColor={iconColor}
+              w="22px"
+              h="22px"
+              borderRadius="6px"
+              cursor="pointer"
+              onClick={() => {
+                setSideBarRemoved(true);
+                removeSideTab('details');
+              }}
+            >
+              <CloseIcon />
+            </Flex>
           </Flex>
         </Flex>
-      </Flex>
-    </Box>
+      </Box>
+    </Flex>
   );
 };
 

--- a/src/pages/Swap/components/history/History.tsx
+++ b/src/pages/Swap/components/history/History.tsx
@@ -1,53 +1,80 @@
-// import { Box } from '@chakra-ui/layout';
-import React from 'react';
-import { Box, Text, Flex, useColorModeValue, Image } from '@chakra-ui/react';
+import React, { useState, useEffect } from 'react';
+import { Box, Text, Flex, useColorModeValue } from '@chakra-ui/react';
 import { CloseIcon, AddIcon } from '../../../../theme/components/Icons';
+import { removeSideTab, checkSideTab } from '../../../../utils/utilsFunctions';
 
 const History = () => {
   const activeTabColor = useColorModeValue('#333333', '#F1F5F8');
   const nonActiveTabColor = useColorModeValue('#CCCCCC', '#4A739B');
   const iconColor = useColorModeValue('#666666', '#DCE5EF');
+  const borderColor = useColorModeValue('#DEE5ED', '#324D68');
+
+  const [sideBarRemoved, setSideBarRemoved] = useState<Boolean>(false);
+
+  useEffect(() => {
+    const isActive = checkSideTab('history');
+    setSideBarRemoved(isActive);
+  }, []);
 
   return (
-    <Box w="100%" pl={3} pr={3}>
-      <Flex alignItems="center" justifyContent="space-between" px={4}>
-        <Flex>
-          <Text fontWeight="400" mr={3} fontSize="16px" color={activeTabColor}>
-            Transaction History
-          </Text>
-          <Text fontWeight="400" fontSize="16px" color={nonActiveTabColor}>
-            Market History
-          </Text>
-        </Flex>
-        <Flex alignItems="center" fontWeight="bold" rounded={100} bg="#">
-          <Flex
-            border="2px"
-            alignItems="center"
-            justifyContent="center"
-            mr={2}
-            color={iconColor}
-            borderColor={iconColor}
-            w="22px"
-            h="22px"
-            borderRadius="6px"
-          >
-            <AddIcon />
+    <Flex
+      h="60px"
+      border="1px"
+      borderColor={borderColor}
+      borderRadius="6px"
+      alignItems="center"
+      display={sideBarRemoved && 'none'}
+    >
+      <Box w="100%" pl={3} my={4} pr={3}>
+        <Flex alignItems="center" justifyContent="space-between" px={4}>
+          <Flex>
+            <Text
+              fontWeight="400"
+              mr={3}
+              fontSize="16px"
+              color={activeTabColor}
+            >
+              Transaction History
+            </Text>
+            <Text fontWeight="400" fontSize="16px" color={nonActiveTabColor}>
+              Market History
+            </Text>
           </Flex>
-          <Flex
-            border="2px"
-            alignItems="center"
-            justifyContent="center"
-            color={iconColor}
-            borderColor={iconColor}
-            w="22px"
-            h="22px"
-            borderRadius="6px"
-          >
-            <CloseIcon />
+          <Flex alignItems="center" fontWeight="bold" rounded={100} bg="#">
+            <Flex
+              border="2px"
+              alignItems="center"
+              justifyContent="center"
+              mr={2}
+              color={iconColor}
+              borderColor={iconColor}
+              w="22px"
+              h="22px"
+              borderRadius="6px"
+            >
+              <AddIcon />
+            </Flex>
+            <Flex
+              border="2px"
+              alignItems="center"
+              justifyContent="center"
+              color={iconColor}
+              borderColor={iconColor}
+              w="22px"
+              h="22px"
+              borderRadius="6px"
+              cursor="pointer"
+              onClick={() => {
+                setSideBarRemoved(true);
+                removeSideTab('history');
+              }}
+            >
+              <CloseIcon />
+            </Flex>
           </Flex>
         </Flex>
-      </Flex>
-    </Box>
+      </Box>
+    </Flex>
   );
 };
 

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import { Box, Flex, useMediaQuery, useColorModeValue } from '@chakra-ui/react';
+import { Box, Flex, useMediaQuery } from '@chakra-ui/react';
 import ShowDetails from './components/details/ShowDetails';
 import SendToken from './components/sendToken/index';
 import History from './components/history/History';
 
 const Swap = () => {
   const [isMobileDevice] = useMediaQuery('(max-width: 750px)');
-  const borderColor = useColorModeValue('#DEE5ED', '#324D68');
   return (
     <Box fontSize="xl">
       <Flex
@@ -23,41 +22,17 @@ const Swap = () => {
             </Box>
 
             <Box mx={4} w={['100%', '100%', '45%', '29.5%']} mb={4}>
-              <Flex
-                h="60px"
-                border="1px"
-                borderColor={borderColor}
-                borderRadius="6px"
-                alignItems="center"
-              >
-                <ShowDetails />
-              </Flex>
+              <ShowDetails />
             </Box>
 
             <Box mx={4} w={['100%', '100%', '45%', '29.5%']} mb={4}>
-              <Flex
-                h="60px"
-                border="1px"
-                borderColor={borderColor}
-                borderRadius="6px"
-                alignItems="center"
-              >
-                <History />
-              </Flex>
+              <History />
             </Box>
           </>
         ) : (
           <>
             <Box mx={4} w={['100%', '100%', '45%', '29.5%']} mb={4}>
-              <Flex
-                h="60px"
-                border="1px"
-                borderColor={borderColor}
-                borderRadius="6px"
-                alignItems="center"
-              >
-                <ShowDetails />
-              </Flex>
+              <ShowDetails />
             </Box>
 
             <Box mx={4} w={['100%', '100%', '45%', '29.5%']} mb={4}>
@@ -65,15 +40,7 @@ const Swap = () => {
             </Box>
 
             <Box mx={5} w={['100%', '100%', '45%', '29.5%']} mb={4}>
-              <Flex
-                h="60px"
-                border="1px"
-                borderColor={borderColor}
-                borderRadius="6px"
-                alignItems="center"
-              >
-                <History />
-              </Flex>
+              <History />
             </Box>
           </>
         )}

--- a/src/theme/components/Icons.tsx
+++ b/src/theme/components/Icons.tsx
@@ -1,4 +1,4 @@
-import { Icon, useColorModeValue, IconProps } from '@chakra-ui/react';
+import { Icon, useColorModeValue } from '@chakra-ui/react';
 import React from 'react';
 import { CgArrowsExchangeAltV } from 'react-icons/cg';
 import { IoSettingsOutline } from 'react-icons/io5';

--- a/src/utils/utilsFunctions.ts
+++ b/src/utils/utilsFunctions.ts
@@ -1,0 +1,12 @@
+export const removeSideTab = (sideBarName: string): void => {
+  localStorage.setItem(sideBarName, 'removed');
+};
+
+export const checkSideTab = (sideBarName: string): Boolean => {
+  const isSidebarActive = localStorage.getItem(sideBarName);
+  if (isSidebarActive === 'removed') {
+    return true;
+  } else {
+    return false;
+  }
+};


### PR DESCRIPTION
#### What does this PR do?
- This PR  implements the function to remove either the details tab or market history tab, it also saves the users preference in localstorage so even if the page is refreshed the removed tabs will remain removed

#### What has been completed?
-  Removable details/history tab
- [ ]

#### How should the changes be manually tested?
- Click on the close icon to remove the tab, to add the icon back manually delete it from your localstorage

#### Any Background context or information you want to provide?
- 

#### Demo Video and screenshots?
https://www.loom.com/share/f593467914804ff19e6791438c7b2f51
-