### PR TITLE
Add Polygon mainnet RGP address to the token list

### DIFF
--- a/src/state/wallet/hooks.ts
+++ b/src/state/wallet/hooks.ts
@@ -29,7 +29,7 @@ import JSBI from "jsbi";
             
             const amount = value ? JSBI.BigInt(value.toString()) : undefined
            if(amount && chainId){
-             const amountValue = parseFloat(ethers.utils.formatEther(amount.toString()))
+             const amountValue = parseFloat(ethers.utils.formatUnits(amount.toString(), currency.decimals))
              amountValue ===  0 ? setBalance('0') : setBalance(amountValue.toFixed(4))
            }
               }

--- a/src/utils/constants/tokenList/rigelprotocol-default.tokenList.json
+++ b/src/utils/constants/tokenList/rigelprotocol-default.tokenList.json
@@ -19,6 +19,14 @@
       "address": "0xFA262F303Aa244f9CC66f312F0755d89C3793192"
     },
     {
+      "symbol": "RGP",
+      "name": "Rigel Protocol",
+      "chainId":137,
+      "decimals":18,
+      "logoURI": "https://bscscan.com/token/images/rigelprotocol_32.png",
+      "address": "0x4AF5ff1A60a6eF6C7c8f9C4E304cD9051fCa3Ec0"
+    },
+    {
       "name": "WBNB Token",
       "symbol": "WBNB",
       "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",


### PR DESCRIPTION
#### What does this PR do?
- Add Polygon mainnet RGP address to the token list

#### What has been completed?
- [x] Added Polygon mainnet RGP address to the token list
- [x] Fixed token formatting by considering the token decimals with formatUnits function.


#### How should the changes be manually tested?
- load the deployed url 
- Click on the select token feature and the token list modal will be displayed
- RGP token is displayed as part of the token list with the balance.

#### Any Background context or information you want to provide?
- The RGP token was recently deployed to Polygon mainnet.

#### Demo Video and screenshots?
-https://www.loom.com/share/9a2f77eca3fc479e99d1c7fdb59e5960