### PR TITLE
Add SHIB and MBOX tokens to default token list

### DIFF
--- a/src/utils/constants/tokenList/rigelprotocol-default.tokenList.json
+++ b/src/utils/constants/tokenList/rigelprotocol-default.tokenList.json
@@ -299,6 +299,38 @@
       "decimals": 18,
       "chainId": 56,
       "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/15043.png"
+    },
+    {
+      "name": "SHIBA INU",
+      "address": "0x2859e4544c4bb03966803b044a93563bd2d0dd4d",
+      "symbol": "SHIB",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://bscscan.com/token/images/shibatoken_32.png"
+    },
+    {
+      "name": "SHIBA INU",
+      "address": "0x30deec86644b16c3f61d8dd5571e88179289445b",
+      "symbol": "SHIB",
+      "decimals": 18,
+      "chainId": 97,
+      "logoURI": "https://bscscan.com/token/images/shibatoken_32.png"
+    },
+    {
+      "name": "Mobox",
+      "address": "0x3203c9e46ca618c8c1ce5dc67e7e9d75f5da2377",
+      "symbol": "MBOX",
+      "decimals": 18,
+      "chainId": 56,
+      "logoURI": "https://bscscan.com/token/images/mobox_32.png"
+    },
+    {
+      "name": "Mobox",
+      "address": "0x46be9c07d1100f7a1259d20398a40deb43e3527c",
+      "symbol": "MBOX",
+      "decimals": 18,
+      "chainId": 97,
+      "logoURI": "https://bscscan.com/token/images/mobox_32.png"
     }
   ]
 }


### PR DESCRIPTION
#### What does this PR do?
- Add SHIB and MBOX tokens to default token list for BSC testnet and mainnet.
- BSC testnet addresses: https://rigel.gitbook.io/tech-testing-note/smartswap/testnet-bsc-addresses
- BSC mainnet addresses: https://rigel.gitbook.io/tech-testing-note/smartswap/main-net-addresses

#### What has been completed?
- [ ] Added SHIB and MBOX tokens to default token list


#### How should the changes be manually tested?
- Click on the deployed link,
- Click on the select token button on the swap component
- The token list modal displays the added SHIB and MBOX tokens

#### Any Background context or information you want to provide?
- N/A

#### Demo Video and screenshots?
- https://www.loom.com/share/dcd99e8004f248fb987a3ed5df4c32e0