### PR TITLE
fixed dropdown on mobile screens

### DIFF
--- a/src/components/Navbar/MobileNavDrawer.tsx
+++ b/src/components/Navbar/MobileNavDrawer.tsx
@@ -11,7 +11,7 @@ import {
   Text,
   Link,
   Collapse,
-  useMediaQuery,
+  useMediaQuery, MenuItem,
 } from '@chakra-ui/react';
 import {
   HamburgerIcon,
@@ -22,6 +22,8 @@ import {
 import { CloseIcon } from '../../theme/components/Icons';
 import { NavLink } from 'react-router-dom';
 import useToggle from '../../utils/hooks/useToggle';
+import {SupportedChainId} from "../../constants/chains";
+import {useActiveWeb3React} from "../../utils/hooks/useActiveWeb3React";
 
 const MobileNavDrawer = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -31,6 +33,8 @@ const MobileNavDrawer = () => {
   const SwapBgColor = useColorModeValue('#F2F5F8', '#213345');
   const closeButtonBorder = useColorModeValue('#666666', '#DCE5EF');
   const [isMobileDevice] = useMediaQuery('(max-width: 750px)');
+
+  const {chainId} = useActiveWeb3React();
 
   const Nav = ({ to, label }: { to: string; label: string }) => (
     <NavLink
@@ -57,6 +61,7 @@ const MobileNavDrawer = () => {
         <HamburgerIcon
           color={HamburgerIconColor}
           onClick={onOpen}
+          cursor={'pointer'}
           w="24px"
           h="24px"
         />
@@ -119,15 +124,16 @@ const MobileNavDrawer = () => {
                     ml={10}
                     mb={3}
                   >
-                    <Text _hover={{ color: '#319EF6' }} mb={2}>
-                      Straight
+                    <Text _hover={{ color: '#319EF6' }} mb={2} onClick={onClose}>
+                      <Nav label="Straight Swap" to="/swap" />
                     </Text>
-                    <Text _focus={{ color: '#319EF6' }} mb={2}>
-                      Set Price
+                    <Text _hover={{ color: '#319EF6' }} mb={2} onClick={onClose}>
+                      <Nav label="Auto-Time" to={chainId === SupportedChainId.BINANCETEST ? '/auto-time' : '#'} />
                     </Text>
-                    <Text _focus={{ color: '#319EF6' }} mb={2}>
-                      Auto-Time
+                    <Text _hover={{ color: '#319EF6' }} mb={2} onClick={onClose}>
+                      <Nav label="Set Price" to={chainId === SupportedChainId.BINANCETEST ? '/set-price' : '#'} />
                     </Text>
+
                   </Flex>
                 </Collapse>
                 <Flex ml={6} mb={3}>

--- a/src/components/Navbar/SwapDropdown.tsx
+++ b/src/components/Navbar/SwapDropdown.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { NavLink } from "react-router-dom";
+import { NavLink, useLocation } from "react-router-dom";
 import {
   Menu,
   MenuButton,
@@ -23,8 +23,19 @@ const Nav = ({ to, label }: { to: string; label: string }) => (
 );
 
 function SwapDropdown() {
-
+    const location = useLocation();
     const {chainId} = useActiveWeb3React();
+    const name = location.pathname;
+
+    const useName = () => {
+        console.log(name);
+        if (name == '/swap'|| name == '/auto-time' || name == '/set-price') {
+            console.log(`Correct name is ${name}`);
+            return name.substring(1);
+        } else {
+            return 'Swap'
+        }
+    };
 
   return (
     <Menu>
@@ -36,8 +47,9 @@ function SwapDropdown() {
         fontWeight={200}
         _focus={{ color: "#319EF6" }}
         fontSize="14px"
+        textTransform={'capitalize'}
       >
-        Swap
+          {useName()}
       </MenuButton>
       <MenuList>
         <MenuItem _focus={{ color: "#319EF6" }}>

--- a/src/hooks/useMint.ts
+++ b/src/hooks/useMint.ts
@@ -15,8 +15,6 @@ import { ZERO_ADDRESS } from "../constants";
 import { ethers } from "ethers";
 import { useSelector } from "react-redux";
 import { RootState } from "../state";
-import { getDecimals } from "../utils/utilsFunctions";
-import { getNativeAddress } from "../utils/hooks/usePools";
 
 const formatAmount = (number: string, decimal: number) => {
   return ethers.utils.formatUnits(number, decimal);
@@ -29,7 +27,6 @@ export const useMint = (
 ) => {
   const { chainId, library } = useActiveWeb3React();
   const [address, setAddress] = useState<string>();
-  const [loading, setLoading] = useState<boolean>(false);
   const [amount, setAmount] = useState<string | undefined>("");
   const [wrap, setWrap] = useState<boolean>(false);
 
@@ -79,7 +76,7 @@ export const useMint = (
         if (!wrappable && address !== ZERO_ADDRESS) {
           setWrap(false);
           if (amountIn !== undefined) {
-            //setLoading(!loading);
+            // setLoading(true);
             const pairinstance = await LiquidityPairInstance(
               pairAddress,
               library

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState, useMemo } from "react";
 import { Field } from "../../state/mint/actions";
-import { RouteComponentProps, useParams } from "react-router-dom";
+import { RouteComponentProps } from "react-router-dom";
 import TransactionSettings from "../../components/TransactionSettings";
 import {
   Box,
@@ -14,9 +14,9 @@ import {
   Divider,
   Center,
 } from "@chakra-ui/react";
+import {ZERO_ADDRESS} from "../../constants";
 import { TimeIcon, ArrowBackIcon, AddIcon } from "@chakra-ui/icons";
 import { useDerivedMintInfo, useMintState } from "../../state/mint/hooks";
-import { useWeb3React } from "@web3-react/core";
 import OutputCurrecy from "./AddLquidityInputs/OutputCurrecy";
 import InputCurrency from "./AddLquidityInputs/InputCurrency";
 import Joyride from "react-joyride";
@@ -24,7 +24,6 @@ import { tourSteps } from "../../components/Onboarding/AddLiquidityStep";
 import { useMintActionHandlers } from "../../state/mint/hooks";
 import {
   useIsPoolsAvailable,
-  usePoolShare,
   usePricePerToken,
   useAllowance,
   usePriceForNewPool,
@@ -38,7 +37,7 @@ import {
   formatAmountIn,
   getOutPutDataFromEvent,
 } from "../../utils/utilsFunctions";
-import { SMARTSWAPROUTER, WNATIVEADDRESSES } from "../../utils/addresses";
+import { SMARTSWAPROUTER } from "../../utils/addresses";
 import { setOpenModal, TrxState } from "../../state/application/reducer";
 import { useDispatch } from "react-redux";
 import { getExplorerLink, ExplorerDataType } from "../../utils/getExplorerLink";
@@ -51,7 +50,6 @@ import { Currency } from "@uniswap/sdk";
 import { SmartSwapRouter } from "../../utils/Contracts";
 import { ethers } from "ethers";
 import { useActiveWeb3React } from "../../utils/hooks/useActiveWeb3React";
-import { SupportedChainSymbols } from "../../utils/constants/chains";
 import { calculateGas } from "../Swap/components/sendToken";
 
 export default function AddLiquidity({
@@ -70,12 +68,12 @@ export default function AddLiquidity({
   const approveButtonColor = useColorModeValue("#FFFFFF", "#F1F5F8");
 
   const { independentField, typedValue, otherTypedValue } = useMintState();
-  const [loading, setLoading] = useState(false);
+  //const [loading, setLoading] = useState(false);
   const [run, setRun] = useState(false);
   const bgColorRide = useColorModeValue("#319EF6", "#4CAFFF");
   const { onCurrencySelection, onUserInput, onCurrencyFor } =
     useMintActionHandlers();
-  const { currencies, getMaxValue, bestTrade, parsedAmount, showWrap } =
+  const { currencies, getMaxValue, bestTrade, parsedAmount, showWrap, address } =
     useDerivedMintInfo();
   const dependentField: Field =
     independentField === Field.INPUT ? Field.OUTPUT : Field.INPUT;
@@ -92,6 +90,7 @@ export default function AddLiquidity({
   const [balanceB, setBalanceB] = useState("");
   const [showModal, setShowModal] = useState(false);
   const [checkTokenApproval, setCheckTokenApproval] = useState(false);
+  const [isLoadingValue, setIsLoadingValue] = useState(false);
 
   const [userSlippageTolerance] = useUserSlippageTolerance();
   const [userDeadline] = useUserTransactionTTL();
@@ -490,9 +489,12 @@ export default function AddLiquidity({
     }
   };
 
-  const [isLoadingValue, setIsLoadingValue] = useState(false);
+
   useEffect(() => {
-    if (formattedAmounts[Field.INPUT] && !formattedAmounts[Field.OUTPUT]) {
+    if (address === ZERO_ADDRESS) {
+      setIsLoadingValue(false)
+    }
+    else if (formattedAmounts[Field.INPUT] && !formattedAmounts[Field.OUTPUT]) {
       setIsLoadingValue(true);
     } else {
       setIsLoadingValue(false);

--- a/src/state/mint/hooks.ts
+++ b/src/state/mint/hooks.ts
@@ -1,13 +1,7 @@
-import {
-  Currency,
-  CurrencyAmount,
-  Percent,
-  Price,
-  Token,
-} from '@uniswap/sdk-core';
+import {Currency} from '@uniswap/sdk-core';
 
 import JSBI from 'jsbi';
-import { ReactNode, useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../index';
 
@@ -113,6 +107,7 @@ export function useDerivedMintInfo(): {
   inputError?: string;
   parsedAmount: string | undefined;
   showWrap: boolean;
+  address: string;
 } {
   const { account } = useActiveWeb3React();
   const [Balance] = useNativeBalance();
@@ -169,5 +164,6 @@ export function useDerivedMintInfo(): {
     bestTrade,
     parsedAmount,
     showWrap,
+    address
   };
 }


### PR DESCRIPTION
#### What does this PR do?
-Fixes the dropdown links on mobile screens.
-Fixes the loading state on the add liquidity page when the pair has not yet been created. 

#### What has been completed?
- Users can now navigate to set-price and auto-time pages on mobile view.
- Loading state only shows when data is being loaded. 

#### How should the changes be manually tested?
-

#### Any Background context or information you want to provide?
-

#### Demo Video and screenshots?
-Loom - https://www.loom.com/share/91a94143311b48e8a8e5a00cef648993
- Loom - https://www.loom.com/share/5878357995f1482eb9f3598dbee823ca